### PR TITLE
Add `getx` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # UniState: A Universal State Management Adapter 🚀
 
-
 | Package                                                                          | Pub                                                                                                         |
 | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | [unistate_provider](https://github.com/aissat/unistate/tree/main/unistate_provider) | [![pub package](https://img.shields.io/pub/v/unistate_provider.svg)](https://pub.dev/packages/unistate_provider) |
 | [unistate_adapter](https://github.com/aissat/unistate/tree/main/unistate_adapter)   | [![pub package](//img.shields.io/pub/v/unistate_adapter.svg)](https://pub.dev/packages/unistate_adapter)         |
-
-
 
 Package Overview  📦  [![pub package](https://img.shields.io/pub/v/unistate.svg)](https://pub.dev/packages/unistate)
 
@@ -20,9 +17,9 @@ The primary goal of UniState is to:
 - **Maintain Code Flexibility**: Allow easy switching between state management approaches
 - **Preserve Flutter's Code Style**: Ensure consistency and idiomatic Flutter development
 
-| Bloc                                                                               | Cubit                                                                                | Provider                                                                                   | getx                                                                                 |
-| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |------------------------------------------------------------------------------------------ |
-| ![Bloc](https://raw.githubusercontent.com/aissat/unistate/main/screenshots/bloc.png) | ![Cubit](https://raw.githubusercontent.com/aissat/unistate/main/screenshots/cubit.png) | ![Provider](https://raw.githubusercontent.com/aissat/unistate/main/screenshots/provider.png) |![Getx](https://raw.githubusercontent.com/aissat/unistate/main/screenshots/getx.png)|
+| Bloc                                                                               | Cubit                                                                                | Provider                                                                                   | getx                                                                               |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| ![Bloc](https://raw.githubusercontent.com/aissat/unistate/main/screenshots/bloc.png) | ![Cubit](https://raw.githubusercontent.com/aissat/unistate/main/screenshots/cubit.png) | ![Provider](https://raw.githubusercontent.com/aissat/unistate/main/screenshots/provider.png) | ![Getx](https://raw.githubusercontent.com/aissat/unistate/main/screenshots/getx.png) |
 
 ### Why UniState? 🤔
 
@@ -59,7 +56,7 @@ The primary purpose of UniState is to:
 
 UniState is designed to work with multiple state management approaches, including but not limited to:
 
-- BLoC 
+- BLoC
 - Cubit
 - Provider
 - Getx
@@ -193,6 +190,8 @@ dependencies:
 
 Here's a simple counter app demonstrating UniState's flexibility:
 
+> You can find the complete example in the [repository](https://github.com/aissat/unistate/tree/main/example).
+
 ```dart
 // Define your state
 class CounterCubit extends Cubit<int> with UnistateCubitMixin<int> {
@@ -251,7 +250,7 @@ class CounterPage extends StatelessWidget {
 - [X] BLoC [WIP]
 - [X] Cubit [WIP]
 - [X] Provider [WIP]
-- [x] Getx [WIP]
+- [X] Getx [WIP]
 - [ ] Riverpod
 
 - Custom State Management Solutions

--- a/unistate_adapter/lib/src/mixin/mixins.dart
+++ b/unistate_adapter/lib/src/mixin/mixins.dart
@@ -1,4 +1,5 @@
+export 'unistate_bloc_mixin.dart';
+export 'unistate_cubit_mixin.dart';
+export 'unistate_getx_mixin.dart';
 export 'unistate_listenable_mixin.dart';
 export 'unistate_notifier_mixin.dart';
-export 'unistate_bloc_mixin.dart';
-export 'unistate_cubit_mixin.dart'; 

--- a/unistate_adapter/lib/src/mixin/unistate_getx_mixin.dart
+++ b/unistate_adapter/lib/src/mixin/unistate_getx_mixin.dart
@@ -37,12 +37,17 @@ mixin UnistateGetxMixin<T extends Object?> on GetxController
   }
 
   void initState(T initialState) {
-    // print('initState');
+    if (_rx != null) {
+      throw StateError('UniStateGetxMixin already initialized');
+    }
     _rx = initialState.obs;
   }
 
   @override
   void onClose() {
+    if (!_listeners.isEmpty) {
+      print('Warning: UniStateGetxMixin disposed with active listeners');
+    }
     _worker?.dispose();
     _worker = null;
     _listeners.clear();

--- a/unistate_adapter/lib/src/mixin/unistate_getx_mixin.dart
+++ b/unistate_adapter/lib/src/mixin/unistate_getx_mixin.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/foundation.dart';
+import 'package:get/get.dart';
+
+/// Mixin for GetX based classes that implements ValueListenable
+mixin UnistateGetxMixin<T extends Object?> on GetxController
+    implements ValueListenable<T> {
+  late final Rx<T> _rx;
+  final List<VoidCallback> _listeners = [];
+  Worker? _worker;
+
+  @override
+  T get value => _rx.value;
+
+  set value(T newState) {
+    _rx.value = newState;
+    // print('emitted: $newState');
+  }
+
+  @override
+  VoidCallback addListener(VoidCallback listener) {
+    // print('addListener');
+    _listeners.add(listener);
+    // print('listeners: ${_listeners.length}');
+
+    // Create worker if it doesn't exist
+    _worker ??= ever(_rx, (_) {
+      // Create a copy of the listeners list to avoid concurrent modification
+      for (var listener in List.of(_listeners)) {
+        listener();
+      }
+    });
+
+    // Return a dispose function
+    return () {
+      removeListener(listener);
+    };
+  }
+
+  void initState(T initialState) {
+    // print('initState');
+    _rx = initialState.obs;
+  }
+
+  @override
+  void onClose() {
+    _worker?.dispose();
+    _worker = null;
+    _listeners.clear();
+    super.onClose();
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    _listeners.remove(listener);
+    if (_listeners.isEmpty) {
+      _worker?.dispose();
+      _worker = null;
+    }
+  }
+}


### PR DESCRIPTION
Support `getx` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new mixin, `UnistateGetxMixin`, for reactive state management in GetX applications.
	- Added a link to a complete example in the "Basic Usage Example" section of the README.

- **Bug Fixes**
	- Improved formatting and clarity in the README, including adjustments to the "Supported State Managers" section.

- **Chores**
	- Reorganized export statements for mixins, adding and removing specific exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->